### PR TITLE
Plugin and Swift EditorService Foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /Packages
 /*.xcodeproj
 compile_commands.json
+*.pyc

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Wrap SPM build system
 # We call the program this.
 PRODUCT=spm-vim
-LAST_LOG=.build/$(CONFIG)/last.log
+LAST_LOG=.build/last_build.log
 
 .PHONY: install
 install: CONFIG=release

--- a/Package.resolved
+++ b/Package.resolved
@@ -38,6 +38,15 @@
         }
       },
       {
+        "package": "SKQueue",
+        "repositoryURL": "https://github.com/daniel-pedersen/SKQueue.git",
+        "state": {
+          "branch": null,
+          "revision": "b6dcd7532f90b0c3abbe624d271f64ac7f393ddf",
+          "version": "1.1.0"
+        }
+      },
+      {
         "package": "SwiftCompilationDatabase",
         "repositoryURL": "https://github.com/jerrymarino/SwiftCompilationDatabase.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -9,13 +9,15 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/Carthage/Commandant", from: "0.13.0"),
         .package(url: "https://github.com/jerrymarino/SwiftCompilationDatabase.git", .branch("master")),
+        .package(url: "https://github.com/daniel-pedersen/SKQueue.git", from: "1.1.0")
+
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "SPMVim",
-            dependencies: ["Commandant", "LogParser"]),
+            dependencies: ["Commandant", "LogParser", "SKQueue"]),
         .testTarget(
             name: "SPMVimTests",
             dependencies: ["SPMVim"]),

--- a/Sources/SPMVim/EditorService.swift
+++ b/Sources/SPMVim/EditorService.swift
@@ -1,0 +1,101 @@
+import Foundation
+import SKQueue
+
+/// EditorService
+/// This is the core plugin backend for SwiftPackageManager.vim
+/// Vim Integration
+/// It communicates with Vim via evaling expressions and running commands
+/// through the Python Vim API
+struct EditorService: SKQueueDelegate {
+    let host: String
+    let authToken: String
+
+    /// The editor listens to updates in this log
+    static let LastBuildLogPath = ".build/last_build.log"
+
+    /// vim.command
+    func vimCommand(command: String) -> String {
+        return post(str: command, method: "c")
+    }
+
+    /// vim.eval
+    func vimEval(eval: String) -> String {
+        return post(str: eval, method: "e")
+    }
+
+    /// Send a POST request and return the body.
+    func post(str: String, method: String) -> String {
+        let commandPath = host + "/" + method
+        let commandData = str.data(using:.ascii)!
+        var request = URLRequest(url: URL(string: commandPath)!)
+        request.httpBody = commandData
+        request.httpMethod = "POST"
+        let semaphore = DispatchSemaphore(value: 0)
+        let session = URLSession.shared
+        var responseStr: String!
+        let task = session.dataTask(with: request) {
+            (data, response, error) in
+            if let error = error {
+                print("error:", error) 
+                responseStr = ""
+            } else {
+                let decodeData = data ?? Data()
+                responseStr = String(data: decodeData, encoding: .ascii) ?? ""
+                semaphore.signal()
+            }
+        }
+
+        task.resume()
+        _ = semaphore.wait(timeout: .distantFuture)
+        return responseStr
+    }
+
+
+    func start() {
+        // Post a message for testing
+        _ = vimCommand(command: "echom 'warning: started experimental spm-vim plugin'")
+
+        // Setup observation for a path
+        let path = vimEval(eval: "expand('%:p')")
+
+        // Search the current path for a "Package.swift"
+        // assume that the build we are watching is in there.
+        let components: [String] = path.components(separatedBy: "/")
+        let packagePath = components.reduce([String]()) {
+            accum, x in
+            if accum.last == "Package.swift" {
+                return accum
+            }
+
+            if accum.count == 0 {
+                return [x]
+            }
+            let maybePath = accum + ["Package.swift"]
+            if FileManager.default.fileExists(atPath: maybePath.joined(separator: "/")) {
+                return maybePath
+            }
+            return accum + [x]
+        }
+
+        var guessedLogDir = packagePath
+        guessedLogDir[packagePath.count - 1] = EditorService.LastBuildLogPath
+        let logPath = guessedLogDir.joined(separator: "/")
+
+        let queue = SKQueue(delegate: self)!
+        queue.addPath(logPath)
+        CFRunLoopRun()
+    }
+
+    // Mark - SKQueueDelegate
+
+    // Observe for changes in the log file
+
+    func receivedNotification(_ notification: SKQueueNotification, path: String, queue: SKQueue) {
+        let messages = "changed " + path + " at " +  notification.toStrings()
+            .map { $0.rawValue }
+            .joined(separator: ",")
+        _ = vimCommand(command: "echom '\(messages)'\n")
+    }
+}
+
+

--- a/Sources/SPMVim/SPMVim.swift
+++ b/Sources/SPMVim/SPMVim.swift
@@ -1,5 +1,0 @@
-struct SPMVim {
-    var text = "Hello, World!"
-}
-
-

--- a/Sources/SPMVim/main.swift
+++ b/Sources/SPMVim/main.swift
@@ -114,10 +114,46 @@ struct CompileCommandsOptions: OptionsProtocol {
     }
 }
 
+struct EditorServiceCommand: CommandProtocol {
+    typealias Options = EditorServiceOptions
+    let verb = "editor"
+    let function = "Operates the editor"
+    let usage =  """
+    Usage:
+      Core editor service   
+    """
+
+    func run(_ options: Options) -> Result<(), BasicError> {
+        let host = "http://localhost:" + options.port
+        let service = EditorService(host: host, authToken: options.authToken)
+        service.start()
+        return .success(())
+    }
+}
+
+struct EditorServiceOptions: OptionsProtocol {
+    let authToken: String
+    let port: String
+
+    static func create(_ authToken: String) -> (String) -> EditorServiceOptions {
+        return { port in
+          EditorServiceOptions(authToken: authToken, port: port)
+        }
+    }
+
+    static func evaluate(_ m: CommandMode) -> Result<EditorServiceOptions, CommandantError<BasicError>> {
+        return create
+            <*> m <| Argument(defaultValue: "", usage: "The auth token for the editor interface")
+            <*> m <| Option(key: "port", defaultValue: "0", usage: "port of the editor interface")
+    }
+}
+
+
 /// Main
 let _ = {
       let commands = CommandRegistry<BasicError>()
       commands.register(LogCommand())
+      commands.register(EditorServiceCommand())
       commands.register(CompileCommandsCommand())
 
       // Commandant Boilderplate

--- a/plugin/spm.vim
+++ b/plugin/spm.vim
@@ -1,0 +1,68 @@
+" Basic example of using Python with vim 
+
+" This is basic vim plugin boilerplate
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! s:UsingPython3()
+  if has('python3')
+    return 1
+  endif
+  return 0
+endfunction
+
+" Prefer py3
+let s:using_python3 = s:UsingPython3()
+let s:python_until_eof = s:using_python3 ? "python3 << EOF" : "python << EOF"
+let s:python_command = s:using_python3 ? "py3 " : "py "
+
+let s:path = fnamemodify(expand('<sfile>:p:h'), ':h')
+
+" Setup some autocmds
+autocmd BufWritePost * call s:OnBufWritePost()
+autocmd CursorMoved * call s:OnCursorMoved()
+autocmd CursorMovedI * call s:OnCursorMovedI()
+autocmd QuitPre      * call s:Pyeval("server.stop()")
+
+" Run some python
+function! s:Pyeval( eval_string )
+  if s:using_python3
+    return py3eval( a:eval_string )
+  endif
+  return pyeval( a:eval_string )
+endfunction
+
+function! s:SetUpPython() abort
+  exec s:python_until_eof
+import vim
+import os
+import sys
+
+# Directory of the plugin
+plugin_dir  = vim.eval('s:path')
+sys.path.insert(0, os.path.join(plugin_dir, 'plugin_python'))
+
+from server import Server
+server = Server()
+server.start()
+vim.command('return 1')
+EOF
+endfunction
+
+function! s:OnCursorMovedI()
+endfunction
+
+function! s:OnCursorMoved()
+endfunction
+
+function! s:OnBufWritePost()
+endfunction
+
+if s:SetUpPython() != 1
+  echom "Setting up python failed..." . s:path
+endif
+
+" This is basic vim plugin boilerplate
+let &cpo = s:save_cpo
+unlet s:save_cpo
+

--- a/plugin_python/server.py
+++ b/plugin_python/server.py
@@ -1,0 +1,100 @@
+from threading import Thread
+from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+import SocketServer
+import vim
+import subprocess
+import os
+import socket
+
+class HTTPRequestHandler(BaseHTTPRequestHandler):
+    def _set_headers(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+
+    def do_GET(self):
+        # Status check
+        self._set_headers()
+        self.wfile.write("true")
+        
+    def do_POST(self):
+        # Main API
+        # /e evaluate an expression
+        # /c execute a command
+        self._set_headers()
+        content_len = int(self.headers.getheader('content-length', 0))
+        post_body = self.rfile.read(content_len)
+        if self.path == "/e":
+            value = vim.eval(post_body)
+            self.wfile.write(value)
+        elif self.path == "/c":
+            value = vim.command(post_body)
+            self.wfile.write(value)
+        else:
+            # FIXME: Send a failing code
+            self.wfile.write("error: unknown path")
+
+    def log_message(self, format, *args):
+        # Disable logging
+        return
+
+
+def GetEditorServicePath():
+    path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..",
+            ".build", "debug", "spm-vim")
+    return path
+
+
+
+def GetUnusedLocalhostPort():
+    sock = socket.socket()
+    # This tells the OS to give us any free port in the range [1024 - 65535]
+    sock.bind(( '', 0 ))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+class Server():
+    def __init__(self):
+        # FIXME: determine dynamically
+        self.port = GetUnusedLocalhostPort()
+
+        self.http_server = HTTPServer(('', self.port), HTTPRequestHandler)
+        self.http_thread = Thread(target=self.run_http_server)
+
+        self.editor_service_path = GetEditorServicePath()
+        self.editor_service_thread = Thread(target=self.run_editor_service)
+
+    def run_editor_service(self):
+        self.editor_service = subprocess.Popen([self.editor_service_path,
+            "editor", "TOK", "--port", str(self.port)])
+
+    def run_http_server(self):
+        try:
+            self.http_server.serve_forever()
+        except:
+            pass
+        finally:
+            self.http_server.server_close()
+
+    def start(self):
+        self.http_thread.start()
+        self.editor_service_thread.start()
+
+    def stop(self):
+        # Close the socket to shutdown the server immediately.
+        # The default implementation takes too long to shutdown,
+        # when vim is trying to exit.
+        try:
+            self.http_server.socket.close()
+        except:
+            pass
+        finally:
+            self.http_thread.join()
+
+        try:
+            self.editor_service.terminate()
+        except:
+            pass
+
+


### PR DESCRIPTION
This patch starts the foundation of sending messages to Vim

The plugin logic will be implemented in Swift and interact with Vim
through sockets.

Currently, it uses HTTP for simplicity.

This approach provides isolation between the plugin and vim, and affords
easy async communication for the plugin that works across NeoVim and
Vim. This is a maintainable way to interface Vim <-> Swift.

Vim:

Bootstrap initial scaffolding.

EditorService:

Setup the core service to interact with the Vim UI.

Right now, it sends messages to the editor when the file .build/Last.log
changes. This is mainly a POC test and uses OSX specific APIs for now.