### PR TITLE
Build Awareness UI Prototype Pass 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,14 @@ build-impl:
 build: CONFIG=debug
 build: build-impl
 
+.PHONY: test
+test: CONFIG=debug
+test:
+	@echo "Testing.."
+	@mkdir -p .build/$(CONFIG)
+	@echo "" > $(LAST_LOG)
+	@swift test -c $(CONFIG) $(SWIFT_OPTS) | tee -a $(LAST_LOG)
+
 .PHONY: release
 release: CONFIG=release
 release: build-impl

--- a/Tests/SPMVimTests/SPMVimTests.swift
+++ b/Tests/SPMVimTests/SPMVimTests.swift
@@ -2,15 +2,21 @@ import XCTest
 @testable import SPMVim
 
 class SPMVimTests: XCTestCase {
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
-        XCTAssertEqual(SPMVim().text, "Hello, World!")
-    }
-
-
     static var allTests = [
-        ("testExample", testExample),
+        ("testErrorExtraction", testErrorExtraction),
     ]
+
+    // FIXME: Move editor service into a testable lib
+    func testErrorExtraction() {
+        let line = "/SwiftPackageManager.vim/Sources/SPMVim/main.swift:6:1: error: use of unresolved identifier 'a'nan^n"
+
+        // let pattern = "(.*)\\+:(\\d\\+):(\\d\\+):\\s*error:\\s*\\(.*\\)$"
+        // FIXME: handle errors of arbitrary len
+        let err = SwiftBuildError.from(line: line)!
+        XCTAssertEqual(err.file, "/SwiftPackageManager.vim/Sources/SPMVim/main.swift")
+        XCTAssertEqual(err.line, 6)
+        XCTAssertEqual(err.col, 1)
+        XCTAssertEqual(err.ty, " error")
+        XCTAssertEqual(err.message, " error: use of unresolved identifier 'a'nan^n")
+    }
 }

--- a/plugin/spm.vim
+++ b/plugin/spm.vim
@@ -20,7 +20,8 @@ let s:path = fnamemodify(expand('<sfile>:p:h'), ':h')
 
 " Setup some autocmds
 autocmd BufWritePost * call s:OnBufWritePost()
-autocmd QuitPre      * call s:Pyeval("server.stop()")
+autocmd QuitPre      * call s:Pyeval("server.Stop()")
+autocmd CursorMoved      * call s:Pyeval("diag_ui.OnCursorMoved()")
 
 " Run some python
 function! s:Pyeval( eval_string )
@@ -41,8 +42,10 @@ plugin_dir  = vim.eval('s:path')
 sys.path.insert(0, os.path.join(plugin_dir, 'plugin_python'))
 
 from server import Server
+from diagnostic_interface import DiagnosticInterface
 server = Server()
-server.start()
+server.Start()
+diag_ui = DiagnosticInterface()
 vim.command('return 1')
 EOF
 endfunction
@@ -73,6 +76,11 @@ fun spm#showerrfile(file)
 			\%f:%l:\ fatal\ error:\ %m,
 			\%f:%l:\ warning:\ %m
     execute "cgetfile " . a:file
+    call s:Pyeval("diag_ui.UpdateBuildState('" . a:file ."')")
+endf
+
+fun spm#showlogs()
+    call s:Pyeval("server.PrintLogs()")
 endf
 
 " This is basic vim plugin boilerplate

--- a/plugin_python/diagnostic_interface.py
+++ b/plugin_python/diagnostic_interface.py
@@ -1,0 +1,308 @@
+# StandIn Diagnostic Interface
+# It should provide similiar functionality from the user perspective
+# without having a dependency on iCompleteMe and the entire ycmd package.
+# This will be moved into pure vimscript and Swift in the future.
+
+from __future__ import absolute_import
+from collections import defaultdict, namedtuple
+
+import vimsupport
+import vim
+import os
+import json
+
+
+class DiagnosticInterface(object):
+    def __init__(self):
+        self._user_options = {
+            'enable_diagnostic_signs': True,
+            'enable_diagnostic_highlighting': True,
+            'echo_current_diagnostic': True
+        }
+        # Line and column numbers are 1-based
+        self._buffer_number_to_line_to_diags = defaultdict(
+            lambda: defaultdict(list))
+        self._next_sign_id = 1
+        self._previous_line_number = -1
+        self._diag_message_needs_clearing = False
+        self._placed_signs = []
+
+    def UpdateBuildState(self, log):
+        """Update Build State from a raw build log"""
+        state_dir = os.path.dirname(log)
+        path = os.path.join(state_dir, "spm_vim_ui.json")
+        with open(path, 'r') as f:
+            state = json.load(f)
+            self._UpdateDiagsFromState(state)
+
+    def _UpdateDiagsFromState(self, state):
+        diags = []
+        if not isinstance(state, list):
+            self.UpdateWithNewDiagnostics(diags)
+            return
+        for err in state:
+            diag = {}
+            diag['text'] = err['message']
+            location = {}
+            location['line_num'] = err['line']
+            location['column_num'] = err['col']
+            location['filepath'] = vimsupport.GetCurrentBufferFilepath()
+            diag['location'] = location
+            diag['kind'] = 'error'
+            location_extent = {}
+            location_extent['start'] = {'line_num': 0}
+            diag['location_extent'] = location_extent
+            diag['ranges'] = []
+            diags.append(diag)
+        self.UpdateWithNewDiagnostics(diags)
+
+    def OnCursorMoved(self):
+        line, _ = vimsupport.CurrentLineAndColumn()
+        line += 1  # Convert to 1-based
+        if line != self._previous_line_number:
+            self._previous_line_number = line
+
+            if self._user_options['echo_current_diagnostic']:
+                self._EchoDiagnosticForLine(line)
+
+    def GetErrorCount(self):
+        return len(self._GetDiagnostics())
+
+    def GetWarningCount(self):
+        return len(self._GetDiagnostics())
+
+    def UpdateWithNewDiagnostics(self, diags):
+        """ Diagnostic format
+            Location {
+                line_num: Number
+                column_num: Number
+                filepath: String
+            }
+
+            Diag {
+                location: Location
+                kind: String
+            }
+        """
+        normalized_diags = [_NormalizeDiagnostic(x) for x in
+                            diags]
+        self._buffer_number_to_line_to_diags = _ConvertDiagListToDict(
+            normalized_diags)
+
+        if self._user_options['enable_diagnostic_signs']:
+            self._placed_signs, self._next_sign_id = _UpdateSigns(
+                self._placed_signs,
+                self._buffer_number_to_line_to_diags,
+                self._next_sign_id)
+
+        if self._user_options['enable_diagnostic_highlighting']:
+            _UpdateSquiggles(self._buffer_number_to_line_to_diags)
+
+    def _EchoDiagnosticForLine(self, line_num):
+        buffer_num = vim.current.buffer.number
+        diags = self._buffer_number_to_line_to_diags[buffer_num][line_num]
+        if not diags:
+            if self._diag_message_needs_clearing:
+                # Clear any previous diag echo
+                vimsupport.PostVimMessage('', warning=False)
+                self._diag_message_needs_clearing = False
+            return
+
+        first_diag = diags[0]
+        text = first_diag['text']
+        if first_diag.get('fixit_available', False):
+            text += ' (FixIt)'
+
+        vimsupport.PostVimMessage(text, warning=False, truncate=True)
+        self._diag_message_needs_clearing = True
+
+    def _GetDiagnostics(self):
+        matched_diags = []
+        line_to_diags = self._buffer_number_to_line_to_diags[
+            vim.current.buffer.number]
+
+        for diags in _IterValues(line_to_diags):
+            matched_diags.extend(list(diags))
+        return matched_diags
+
+
+def _UpdateSquiggles(buffer_number_to_line_to_diags):
+    vimsupport.ClearIcmSyntaxMatches()
+    line_to_diags = buffer_number_to_line_to_diags[vim.current.buffer.number]
+
+    for diags in _IterValues(line_to_diags):
+        # Insert squiggles in reverse order so that errors overlap warnings.
+        for diag in reversed(diags):
+            location_extent = diag['location_extent']
+            is_error = _DiagnosticIsError(diag)
+
+            if location_extent['start']['line_num'] <= 0:
+                location = diag['location']
+                vimsupport.AddDiagnosticSyntaxMatch(
+                    location['line_num'],
+                    location['column_num'],
+                    is_error=is_error)
+            else:
+                vimsupport.AddDiagnosticSyntaxMatch(
+                    location_extent['start']['line_num'],
+                    location_extent['start']['column_num'],
+                    location_extent['end']['line_num'],
+                    location_extent['end']['column_num'],
+                    is_error=is_error)
+
+            for diag_range in diag['ranges']:
+                vimsupport.AddDiagnosticSyntaxMatch(
+                    diag_range['start']['line_num'],
+                    diag_range['start']['column_num'],
+                    diag_range['end']['line_num'],
+                    diag_range['end']['column_num'],
+                    is_error=is_error)
+
+
+def _UpdateSigns(placed_signs, buffer_number_to_line_to_diags, next_sign_id):
+    new_signs, kept_signs, next_sign_id = _GetKeptAndNewSigns(
+        placed_signs, buffer_number_to_line_to_diags, next_sign_id
+    )
+    # Dummy sign used to prevent "flickering" in Vim when last mark gets
+    # deleted from buffer. Dummy sign prevents Vim to collapsing the sign column
+    # in that case.
+    # There's also a vim bug which causes the whole window to redraw in some
+    # conditions (vim redraw logic is very complex). But, somehow, if we place a
+    # dummy sign before placing other "real" signs, it will not redraw the
+    # buffer (patch to vim pending).
+    dummy_sign_needed = not kept_signs and new_signs
+
+    if dummy_sign_needed:
+        vimsupport.PlaceDummySign(next_sign_id + 1,
+                                  vim.current.buffer.number,
+                                  new_signs[0].line)
+
+    # We place only those signs that haven't been placed yet.
+    new_placed_signs = _PlaceNewSigns(kept_signs, new_signs)
+
+    # We use incremental placement, so signs that already placed on the correct
+    # lines will not be deleted and placed again, which should improve performance
+    # in case of many diags. Signs which don't exist in the current diag should be
+    # deleted.
+    _UnplaceObsoleteSigns(kept_signs, placed_signs)
+
+    if dummy_sign_needed:
+        vimsupport.UnPlaceDummySign(
+            next_sign_id + 1, vim.current.buffer.number)
+
+    return new_placed_signs, next_sign_id
+
+
+def _GetKeptAndNewSigns(placed_signs, buffer_number_to_line_to_diags,
+                        next_sign_id):
+    new_signs = []
+    kept_signs = []
+    for buffer_number, line_to_diags in _IterItems(
+            buffer_number_to_line_to_diags):
+        if not vimsupport.BufferIsVisible(buffer_number):
+            continue
+
+        for line, diags in _IterItems(line_to_diags):
+            # Only one sign is visible by line.
+            first_diag = diags[0]
+            sign = _DiagSignPlacement(next_sign_id,
+                                      line,
+                                      buffer_number,
+                                      _DiagnosticIsError(first_diag))
+            if sign not in placed_signs:
+                new_signs.append(sign)
+                next_sign_id += 1
+            else:
+                # We use .index here because `sign` contains a new id, but
+                # we need the sign with the old id to unplace it later on.
+                # We won't be placing the new sign.
+                kept_signs.append(placed_signs[placed_signs.index(sign)])
+    return new_signs, kept_signs, next_sign_id
+
+
+def _PlaceNewSigns(kept_signs, new_signs):
+    placed_signs = kept_signs[:]
+    for sign in new_signs:
+        # Do not set two signs on the same line, it will screw up storing sign
+        # locations.
+        if sign in placed_signs:
+            continue
+        vimsupport.PlaceSign(sign.id, sign.line, sign.buffer, sign.is_error)
+        placed_signs.append(sign)
+    return placed_signs
+
+
+def _UnplaceObsoleteSigns(kept_signs, placed_signs):
+    for sign in placed_signs:
+        if sign not in kept_signs:
+            vimsupport.UnplaceSignInBuffer(sign.buffer, sign.id)
+
+
+def _ConvertDiagListToDict(diag_list):
+    buffer_to_line_to_diags = defaultdict(lambda: defaultdict(list))
+    for diag in diag_list:
+        location = diag['location']
+        buffer_number = vimsupport.GetBufferNumberForFilename(
+            location['filepath'])
+        line_number = location['line_num']
+        buffer_to_line_to_diags[buffer_number][line_number].append(diag)
+
+    for line_to_diags in _IterValues(buffer_to_line_to_diags):
+        for diags in _IterValues(line_to_diags):
+            # We want errors to be listed before warnings so that errors aren't hidden
+            # by the warnings.
+            diags.sort(key=lambda diag: (diag['kind'],
+                                         diag['location']['column_num']))
+    return buffer_to_line_to_diags
+
+
+# Fixme: Determine this in a better way
+def _DiagnosticIsError(diag):
+    return True
+
+
+def _DiagnosticIsWarning(diag):
+    return True
+
+
+def _NormalizeDiagnostic(diag):
+    def ClampToOne(value):
+        return value if value > 0 else 1
+
+    location = diag['location']
+    location['column_num'] = ClampToOne(location['column_num'])
+    location['line_num'] = ClampToOne(location['line_num'])
+    return diag
+
+
+class _DiagSignPlacement(
+    namedtuple("_DiagSignPlacement",
+               ['id', 'line', 'buffer', 'is_error'])):
+    # We want two signs that have different ids but the same location to compare
+    # equal. ID doesn't matter.
+    def __eq__(self, other):
+        return (self.line == other.line and
+                self.buffer == other.buffer and
+                self.is_error == other.is_error)
+
+# Utilities
+
+
+def _IterValues(obj, **kwargs):
+    """Use this only if compatibility with Python versions before 2.7 is
+    required. Otherwise, prefer viewvalues().
+    """
+    func = getattr(obj, "itervalues", None)
+    if not func:
+        func = obj.values
+    return func(**kwargs)
+
+
+def _IterItems(obj, **kwargs):
+    """Use this only if compatibility with Python versions before 2.7 is
+    required. Otherwise, prefer viewitems().
+    """
+    func = getattr(obj, "iteritems", None)
+    if not func:
+        func = obj.items
+    return func(**kwargs)

--- a/plugin_python/server.py
+++ b/plugin_python/server.py
@@ -5,6 +5,39 @@ import vim
 import subprocess
 import os
 import socket
+import traceback
+import tempfile
+
+
+# Utils
+
+def CreateLogfile(prefix=''):
+    with tempfile.NamedTemporaryFile(prefix=prefix,
+                                     suffix='.log',
+                                     delete=False) as logfile:
+        return logfile.name
+
+
+def VimToPythonType(result):
+    if not (isinstance(result, str) or isinstance(result, bytes)):
+        return result
+
+    try:
+        return int(result)
+    except ValueError:
+        return ToUnicode(result)
+
+
+def ToUnicode(value):
+    if not value:
+        return str()
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bytes):
+        # All incoming text should be utf8
+        return str(value, 'utf8')
+    return str(value)
+
 
 class HTTPRequestHandler(BaseHTTPRequestHandler):
     def _set_headers(self):
@@ -15,24 +48,35 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         # Status check
         self._set_headers()
-        self.wfile.write("true")
-        
+        self.wfile.write('true')
+
     def do_POST(self):
+        try:
+            self._run_POST()
+        except Exception, e:
+            traceback.print_exc()
+
+    def _run_POST(self):
         # Main API
         # /e evaluate an expression
         # /c execute a command
         self._set_headers()
         content_len = int(self.headers.getheader('content-length', 0))
         post_body = self.rfile.read(content_len)
-        if self.path == "/e":
-            value = vim.eval(post_body)
-            self.wfile.write(value)
-        elif self.path == "/c":
-            value = vim.command(post_body)
-            self.wfile.write(value)
+        # Consider putting this on a queue
+        if self.path == '/e':
+            value = VimToPythonType(vim.eval(post_body))
+            if not value:
+                value = ''
+            self.wfile.write(value.encode('ascii'))
+        elif self.path == '/c':
+            value = VimToPythonType(vim.command(post_body))
+            if not value:
+                value = ''
+            self.wfile.write(value.encode('ascii'))
         else:
             # FIXME: Send a failing code
-            self.wfile.write("error: unknown path")
+            self.wfile.write('error: unknown path'.encode('ascii'))
 
     def log_message(self, format, *args):
         # Disable logging
@@ -40,19 +84,19 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
 
 
 def GetEditorServicePath():
-    path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..",
-            ".build", "debug", "spm-vim")
+    path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..',
+                        '.build', 'debug', 'spm-vim')
     return path
-
 
 
 def GetUnusedLocalhostPort():
     sock = socket.socket()
     # This tells the OS to give us any free port in the range [1024 - 65535]
-    sock.bind(( '', 0 ))
+    sock.bind(('', 0))
     port = sock.getsockname()[1]
     sock.close()
     return port
+
 
 class Server():
     def __init__(self):
@@ -60,28 +104,19 @@ class Server():
         self.port = GetUnusedLocalhostPort()
 
         self.http_server = HTTPServer(('', self.port), HTTPRequestHandler)
-        self.http_thread = Thread(target=self.run_http_server)
+        self.http_thread = Thread(target=self._RunHttpServer)
+
+        self.stdout_log = CreateLogfile('stdout')
+        self.stderr_log = CreateLogfile('stderr')
 
         self.editor_service_path = GetEditorServicePath()
-        self.editor_service_thread = Thread(target=self.run_editor_service)
+        self.editor_service_thread = Thread(target=self._RunEditorService)
 
-    def run_editor_service(self):
-        self.editor_service = subprocess.Popen([self.editor_service_path,
-            "editor", "TOK", "--port", str(self.port)])
-
-    def run_http_server(self):
-        try:
-            self.http_server.serve_forever()
-        except:
-            pass
-        finally:
-            self.http_server.server_close()
-
-    def start(self):
+    def Start(self):
         self.http_thread.start()
         self.editor_service_thread.start()
 
-    def stop(self):
+    def Stop(self):
         # Close the socket to shutdown the server immediately.
         # The default implementation takes too long to shutdown,
         # when vim is trying to exit.
@@ -97,4 +132,21 @@ class Server():
         except:
             pass
 
+    def PrintLogs(self):
+        print("stdout: " + self.stdout_log)
+        print("stderr: " + self.stderr_log)
 
+    def _RunEditorService(self):
+        with open(self.stdout_log, 'w') as out, open(self.stderr_log, 'w') as err:
+            cmd = [self.editor_service_path,
+                   'editor', 'TOK', '--port', str(self.port)]
+            self.editor_service = subprocess.Popen(cmd, stdout=out)
+            self.editor_service.communicate()
+
+    def _RunHttpServer(self):
+        try:
+            self.http_server.serve_forever()
+        except:
+            pass
+        finally:
+            self.http_server.server_close()

--- a/plugin_python/vimsupport.py
+++ b/plugin_python/vimsupport.py
@@ -1,0 +1,273 @@
+# The primary function of these utils is to support the iCompleteMe compatible
+# DiagnosticUI.
+
+import vim
+import os
+import json
+
+# FIXME: Remove this
+PY2 = True
+
+
+def CurrentLineAndColumn():
+    """Returns the 0-based current line and 0-based current column."""
+    # See the comment in CurrentColumn about the calculation for the line and
+    # column number
+    line, column = vim.current.window.cursor
+    line -= 1
+    return line, column
+
+
+def SetLocationList(diagnostics):
+    """Populate the location list with diagnostics. Diagnostics should be in
+    qflist format; see ":h setqflist" for details."""
+    vim.eval('setloclist( 0, {0} )'.format(json.dumps(diagnostics)))
+
+
+def BufferModified(buffer_object):
+    return bool(int(GetBufferOption(buffer_object, 'mod')))
+
+
+def GetBufferNumberForFilename(filename, open_file_if_needed=True):
+    return GetIntValue(u"bufnr('{0}', {1})".format(
+        EscapeForVim(os.path.realpath(filename)),
+        int(open_file_if_needed)))
+
+
+def GetCurrentBufferFilepath():
+    return GetBufferFilepath(vim.current.buffer)
+
+
+def BufferIsVisible(buffer_number):
+    if buffer_number < 0:
+        return False
+    window_number = GetIntValue("bufwinnr({0})".format(buffer_number))
+    return window_number != -1
+
+
+def GetBufferFilepath(buffer_object):
+    if buffer_object.name:
+        return buffer_object.name
+    # Buffers that have just been created by a command like :enew don't have any
+    # buffer name so we use the buffer number for that.
+    return os.path.join(GetCurrentDirectory(), str(buffer_object.number))
+
+
+def PlaceSign(sign_id, line_num, buffer_num, is_error=True):
+    # libclang can give us diagnostics that point "outside" the file; Vim borks
+    # on these.
+    if line_num < 1:
+        line_num = 1
+
+    sign_name = 'IcmError' if is_error else 'IcmWarning'
+    vim.command('sign place {0} name={1} line={2} buffer={3}'.format(
+        sign_id, sign_name, line_num, buffer_num))
+
+
+def PlaceDummySign(sign_id, buffer_num, line_num):
+    if buffer_num < 0 or line_num < 0:
+        return
+    vim.command('sign define icm_dummy_sign')
+    vim.command(
+        'sign place {0} name=icm_dummy_sign line={1} buffer={2}'.format(
+            sign_id,
+            line_num,
+            buffer_num,
+        )
+    )
+
+
+def UnplaceSignInBuffer(buffer_number, sign_id):
+    if buffer_number < 0:
+        return
+    vim.command(
+        'try | exec "sign unplace {0} buffer={1}" | catch /E158/ | endtry'.format(
+            sign_id, buffer_number))
+
+
+def UnPlaceDummySign(sign_id, buffer_num):
+    if buffer_num < 0:
+        return
+    vim.command('sign undefine icm_dummy_sign')
+
+    vim.command('sign unplace {0} buffer={1}'.format(sign_id, buffer_num))
+
+
+def EscapeForVim(text):
+    return ToUnicode(text.replace("'", "''"))
+
+
+# Type helpers
+def VariableExists(variable):
+    return GetBoolValue("exists( '{0}' )".format(EscapeForVim(variable)))
+
+
+def SetVariableValue(variable, value):
+    vim.command("let {0} = {1}".format(variable, json.dumps(value)))
+
+
+def GetVariableValue(variable):
+    return vim.eval(variable)
+
+
+def GetBoolValue(variable):
+    return bool(int(vim.eval(variable)))
+
+
+def GetIntValue(variable):
+    return int(vim.eval(variable))
+
+
+def AddDiagnosticSyntaxMatch(line_num,
+                             column_num,
+                             line_end_num=None,
+                             column_end_num=None,
+                             is_error=True):
+    """Highlight a range in the current window starting from
+    (|line_num|, |column_num|) included to (|line_end_num|, |column_end_num|)
+    excluded. If |line_end_num| or |column_end_num| are not given, highlight the
+    character at (|line_num|, |column_num|). Both line and column numbers are
+    1-based. Return the ID of the newly added match."""
+    group = 'IcmErrorSection' if is_error else 'IcmWarningSection'
+
+    line_num, column_num = LineAndColumnNumbersClamped(line_num, column_num)
+
+    if not line_end_num or not column_end_num:
+        return GetIntValue(
+            "matchadd('{0}', '\%{1}l\%{2}c')".format(group, line_num, column_num))
+
+    # -1 and then +1 to account for column end not included in the range.
+    line_end_num, column_end_num = LineAndColumnNumbersClamped(
+        line_end_num, column_end_num - 1)
+    column_end_num += 1
+
+    return GetIntValue(
+        "matchadd('{0}', '\%{1}l\%{2}c\_.\\{{-}}\%{3}l\%{4}c')".format(
+            group, line_num, column_num, line_end_num, column_end_num))
+
+
+# Clamps the line and column numbers so that they are not past the contents of
+# the buffer. Numbers are 1-based byte offsets.
+def LineAndColumnNumbersClamped(line_num, column_num):
+    new_line_num = line_num
+    new_column_num = column_num
+
+    max_line = len(vim.current.buffer)
+    if line_num and line_num > max_line:
+        new_line_num = max_line
+
+    max_column = len(vim.current.buffer[new_line_num - 1])
+    if column_num and column_num > max_column:
+        new_column_num = max_column
+
+    return new_line_num, new_column_num
+
+
+def PostVimMessage(message, warning=True, truncate=False):
+    """Display a message on the Vim status line. By default, the message is
+    highlighted and logged to Vim command-line history (see :h history).
+    Unset the |warning| parameter to disable this behavior. Set the |truncate|
+    parameter to avoid hit-enter prompts (see :h hit-enter) when the message is
+    longer than the window width."""
+    echo_command = 'echom' if warning else 'echo'
+
+    # Displaying a new message while previous ones are still on the status line
+    # might lead to a hit-enter prompt or the message appearing without a
+    # newline so we do a redraw first.
+    vim.command('redraw')
+
+    if warning:
+        vim.command('echohl WarningMsg')
+
+    message = ToUnicode(message)
+
+    if truncate:
+        vim_width = GetIntValue('&columns')
+
+        message = message.replace('\n', ' ')
+        if len(message) > vim_width:
+            message = message[: vim_width - 4] + '...'
+
+        old_ruler = GetIntValue('&ruler')
+        old_showcmd = GetIntValue('&showcmd')
+        vim.command('set noruler noshowcmd')
+
+        vim.command("{0} '{1}'".format(echo_command,
+                                       EscapeForVim(message)))
+
+        SetVariableValue('&ruler', old_ruler)
+        SetVariableValue('&showcmd', old_showcmd)
+    else:
+        for line in message.split('\n'):
+            vim.command("{0} '{1}'".format(echo_command,
+                                           EscapeForVim(line)))
+
+    if warning:
+        vim.command('echohl None')
+
+
+def ClearIcmSyntaxMatches():
+    matches = VimExpressionToPythonType('getmatches()')
+    for match in matches:
+        if match['group'].startswith('Icm'):
+            vim.eval('matchdelete({0})'.format(match['id']))
+
+
+def VimExpressionToPythonType(vim_expression):
+    """Returns a Python type from the return value of the supplied Vim expression.
+    If the expression returns a list, dict or other non-string type, then it is
+    returned unmodified. If the string return can be converted to an
+    integer, returns an integer, otherwise returns the result converted to a
+    Unicode string."""
+
+    result = vim.eval(vim_expression)
+    if not (isinstance(result, str) or isinstance(result, bytes)):
+        return result
+
+    try:
+        return int(result)
+    except ValueError:
+        return ToUnicode(result)
+
+
+# Utils
+
+def ToUnicode(value):
+    if not value:
+        return str()
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bytes):
+        # All incoming text should be utf8
+        return str(value, 'utf8')
+    return str(value)
+
+
+# When lines is an iterable of all strings or all bytes, equivalent to
+#   '\n'.join( ToUnicode( lines ) )
+# but faster on large inputs.
+def JoinLinesAsUnicode(lines):
+    try:
+        first = next(iter(lines))
+    except StopIteration:
+        return str()
+
+    if isinstance(first, str):
+        return ToUnicode('\n'.join(lines))
+    if isinstance(first, bytes):
+        return ToUnicode(b'\n'.join(lines))
+    raise ValueError('lines must contain either strings or bytes.')
+
+
+def GetCurrentDirectory():
+    """Returns the current directory as an unicode object. If the current
+    directory does not exist anymore, returns the temporary folder instead."""
+    try:
+        if PY2:
+            return os.getcwdu()
+        return os.getcwd()
+    # os.getcwdu throws an OSError exception when the current directory has been
+    # deleted while os.getcwd throws a FileNotFoundError, which is a subclass of
+    # OSError.
+    except OSError:
+        return tempfile.gettempdir()


### PR DESCRIPTION
This patch factors out diagnostic interface from iCompleteMe into a
simple python 2.7 program: the minimal requirements to display
diagnostics. It's fully compatible with iCompleteMe diagnostics and
produces a similar UI.

Currently, it finds errors from a raw build log in EditorService and
outputs models for the UI. The UI automatically updates and shows signs.

There are quite a bit of unideal and hacky parts to this. It is
mainly a prototype to get things working and experiment.

Ideally:
- Send an entire description of vim state to the UI via RPC
- Write a fast diagnostic UI and RPC layer without python