### PR TITLE
Swift Native Vim Bridge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,14 @@
 PRODUCT=spm-vim
 LAST_LOG=.build/last_build.log
 
+PYTHON_INCLUDE=/System/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7/
+
+# For now, we don't build any of the native swift stuff
+all: install
+
 .PHONY: install
 install: CONFIG=release
+install: SWIFT_OPTS=--product SPMVim
 install: build-impl
 	@echo "Installing to /usr/local/bin/$(PRODUCT)"
 	ditto .build/$(CONFIG)/$(PRODUCT) /usr/local/bin/$(PRODUCT)
@@ -15,13 +21,16 @@ build-impl:
 	@mkdir -p .build/$(CONFIG)
 	@echo "" > $(LAST_LOG)
 	@swift build -c $(CONFIG) $(SWIFT_OPTS) | tee -a $(LAST_LOG)
-	@mv .build/$(CONFIG)/SPMVim .build/$(CONFIG)/$(PRODUCT)
+	@mv .build/$(CONFIG)/SPMVim .build/$(CONFIG)/$(PRODUCT) || true
 
 build: CONFIG=debug
+build: SWIFT_OPTS=--product SPMVim
 build: build-impl
 
 .PHONY: test
 test: CONFIG=debug
+test: SWIFT_OPTS= \
+	-Xcc -I -Xcc $(PYTHON_INCLUDE) -Xlinker -framework -Xlinker Python -Xcc -DSPMVIM_LOADSTUB_RUNTIME
 test:
 	@echo "Testing.."
 	@mkdir -p .build/$(CONFIG)
@@ -30,6 +39,7 @@ test:
 
 .PHONY: release
 release: CONFIG=release
+release: SWIFT_OPTS=--product SPMVim
 release: build-impl
 
 # Running: Pipe the parseable output example to the program
@@ -48,6 +58,18 @@ clean:
 	rm -rf .build/debug/*
 	rm -rf .build/release/*
 
+# This is the core python module
+# FIXME: Consider moving this into SPM
+.build/swiftvim.so: SWIFT_OPTS=--product VimCore  \
+	-Xcc -I -Xcc $(PYTHON_INCLUDE) -Xlinker -framework -Xlinker Python 
+.build/swiftvim.so: CONFIG=debug
+.build/swiftvim.so: Sources/*.c build-impl
+	clang Sources/swiftvim.c -shared -o .build/swiftvim.so  -framework Python -I $(PYTHON_INCLUDE) $(PWD)/.build/$(CONFIG)/libVimCore.dylib
+
+.PHONY: run_py
+run_py: .build/swiftvim.so
+	python Utils/main.py
+
 # Build compile_commands.json
 # Unfortunately, we need to clean.
 # Use the last installed product incase we messed something up during
@@ -56,4 +78,6 @@ compile_commands.json: SWIFT_OPTS=-Xswiftc -parseable-output
 compile_commands.json: CONFIG=debug
 compile_commands.json: clean build-impl
 	cat $(LAST_LOG) | /usr/local/bin/$(PRODUCT) compile_commands
+
+
 

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,18 @@ import PackageDescription
 
 let package = Package(
     name: "SPMVim",
+
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "VimCore",
+            type: .dynamic,
+            targets: ["VimCore"]),
+        .library(
+            name: "VimInterface",
+            targets: ["VimInterface"]),
+    ],
+
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/Carthage/Commandant", from: "0.13.0"),
@@ -12,14 +24,24 @@ let package = Package(
         .package(url: "https://github.com/daniel-pedersen/SKQueue.git", from: "1.1.0")
 
     ],
+
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(name: "VimCore",
+            dependencies: ["VimInterface"]),
+        .target(name: "VimInterface",
+            dependencies: []),
+        .target(name: "EditorService",
+            dependencies: ["LogParser", "SKQueue"]),
         .target(
             name: "SPMVim",
-            dependencies: ["Commandant", "LogParser", "SKQueue"]),
+            dependencies: ["Commandant", "LogParser", "EditorService"]),
         .testTarget(
             name: "SPMVimTests",
-            dependencies: ["SPMVim"]),
+            dependencies: ["EditorService"]),
+        .testTarget(
+            name: "VimInterfaceTests",
+            dependencies: ["VimInterface"]),
     ]
 )

--- a/Sources/EditorService/EditorService.swift
+++ b/Sources/EditorService/EditorService.swift
@@ -1,14 +1,14 @@
 import Foundation
 import SKQueue
 
-struct SwiftBuildError: Codable {
-    let file: String
-    let line: Int
-    let col: Int
-    let ty: String
-    let message: String
+public struct SwiftBuildError: Codable {
+    public let file: String
+    public let line: Int
+    public let col: Int
+    public let ty: String
+    public let message: String
 
-    static func from(line: String) -> SwiftBuildError? {
+    public static func from(line: String) -> SwiftBuildError? {
         let components = line.components(separatedBy: ":")
         guard components.count > 4 else {
             return nil
@@ -28,13 +28,18 @@ struct SwiftBuildError: Codable {
 /// Vim Integration
 /// It communicates with Vim via evaling expressions and running commands
 /// through the Python Vim API
-struct EditorService: SKQueueDelegate {
+public struct EditorService: SKQueueDelegate {
     let host: String
     let authToken: String
 
     /// The editor listens to updates in this log
     static let LastBuildLogPath = ".build/last_build.log"
     static let VimUIStatePath = ".build/spm_vim_ui.json"
+
+    public init(host: String, authToken: String) {
+        self.host = host
+        self.authToken = authToken
+    }
 
     /// vim.command
     func vimCommand(command: String) -> String {
@@ -103,7 +108,7 @@ struct EditorService: SKQueueDelegate {
         }
     }
 
-    func start() {
+    public func start() {
         // Find the SPMPackage path - search the CWD, then the file in Vim
         // Case 1: the user has cd'd into a SPM dir.
         // Case 2: the user is Vimming a file in some package.
@@ -122,7 +127,7 @@ struct EditorService: SKQueueDelegate {
 
     // Observe for changes in the log file
 
-    func receivedNotification(_ notification: SKQueueNotification, path: String, queue: SKQueue) {
+    public func receivedNotification(_ notification: SKQueueNotification, path: String, queue: SKQueue) {
         // This has the effect, that when the log file changes completed,
         // errors are shown in vim. Since this code doesn't understand the
         // notion of a `build` we just naievely update the UI

--- a/Sources/SPMVim/main.swift
+++ b/Sources/SPMVim/main.swift
@@ -2,6 +2,7 @@ import Commandant
 import Result
 import LogParser
 import Foundation
+import EditorService
 
 func getPath(path: String?, relativeTo: String) -> String? {
     if let path = path,

--- a/Sources/VimCore/PluginMain.swift
+++ b/Sources/VimCore/PluginMain.swift
@@ -1,0 +1,67 @@
+import Foundation
+import VimInterface
+
+// This is an example of some timer running
+// This is mainly added to experiment with pythons main thread
+// and will go away.
+// https://medium.com/@danielgalasko/a-background-repeating-timer-in-swift-412cecfd2ef9
+class RepeatingTimer {
+    let timeInterval: TimeInterval
+    init(timeInterval: TimeInterval) {
+        self.timeInterval = timeInterval
+    }
+    private lazy var timer: DispatchSourceTimer = {
+        let t = DispatchSource.makeTimerSource()
+        t.schedule(deadline:.now() + self.timeInterval,
+                   repeating: self.timeInterval)
+        t.setEventHandler(handler: { [weak self] in
+            self?.eventHandler?()
+        })
+        return t
+    }()
+    var eventHandler: (() -> Void)?
+    private enum State {
+        case suspended
+        case resumed
+    }
+    private var state: State = .suspended
+    func resume() {
+        if state == .resumed {
+            return
+        }
+        state = .resumed
+        timer.resume()
+    }
+
+    func suspend() {
+        if state == .suspended {
+            return
+        }
+        state = .suspended
+        timer.suspend()
+    }
+}
+
+// Note: that dispatch main doesn't seem to work in the py process
+// due to lack of "parking"
+class Runner: NSObject {
+    let thread = Thread.current
+    let rl = RunLoop.current
+
+    @objc
+    func run(){
+        print("STAT", rl == RunLoop.current)
+    }
+}
+
+let runner = Runner()
+let timer = RepeatingTimer(timeInterval: 1.0)
+
+// Core bootstrap
+@_cdecl("plugin_init")
+public func plugin_init(){
+    timer.eventHandler = {
+        runner.perform(#selector(runner.run), with: runner.thread)
+    }
+    timer.resume()
+}

--- a/Sources/VimInterface/include/VimInterface/module.modulemap
+++ b/Sources/VimInterface/include/VimInterface/module.modulemap
@@ -1,0 +1,4 @@
+module VimInterface {
+    header "spmvim.h"
+    export *
+}

--- a/Sources/VimInterface/include/VimInterface/swiftvim.h
+++ b/Sources/VimInterface/include/VimInterface/swiftvim.h
@@ -1,0 +1,18 @@
+// Main vimscript methods
+void *swiftvim_command(const char *command);
+void *swiftvim_expr(const char *expr);
+
+// Internally, the API uses reference counting
+void *swiftvim_decref(void *value); 
+void *swiftvim_incref(void *value);
+
+// Value extraction
+const char *swiftvim_asstring(void *value);
+int swiftvim_asint(void *value);
+
+// Bootstrapping
+// Note: These methods are only for testing purposes
+void swiftvim_initialize();
+void swiftvim_finalize();
+void *swiftvim_call(const char *module, const char *method, const char *str); 
+

--- a/Sources/VimInterface/swiftvim_lib.c
+++ b/Sources/VimInterface/swiftvim_lib.c
@@ -1,0 +1,112 @@
+#include <Python.h>
+#include <unistd.h>
+
+// module=vim, method=command|exec, str = value
+void *swiftvim_call(const char *module, const char *method, const char *str) {
+    PyObject *pName, *pModule, *pDict, *pFunc;
+    PyObject *pArgs, *pValue;
+
+    pName = PyString_FromString(module);
+    /* Error checking of pName left out */
+
+    pModule = PyImport_Import(pName);
+    Py_DECREF(pName);
+
+    if (pModule == NULL) {
+        PyErr_Print();
+        fprintf(stderr, "Failed to load \"%s\"\n", module);
+        return NULL;
+    }
+
+    void *outValue = NULL;
+    pFunc = PyObject_GetAttrString(pModule, method);
+    // pFunc is a new reference 
+    if (pFunc && PyCallable_Check(pFunc)) {
+        pArgs = PyTuple_New(1);
+        pValue = PyString_FromString(str);
+        if (!pValue) {
+            Py_DECREF(pArgs);
+            Py_DECREF(pModule);
+            fprintf(stderr, "Cannot convert argument\n");
+            return NULL;
+        }
+
+        int argOffset = 0;
+        PyTuple_SetItem(pArgs, argOffset, pValue);
+        pValue = PyObject_CallObject(pFunc, pArgs);
+        Py_DECREF(pArgs);
+        if (pValue != NULL) {
+
+#ifdef SPMVIM_PY_DEBUG
+            printf("Result of call: %ld\n", PyInt_AsLong(pValue));
+#endif
+            outValue = pValue;
+        } else {
+            Py_DECREF(pFunc);
+            Py_DECREF(pModule);
+            PyErr_Print();
+            fprintf(stderr,"Call failed\n");
+            return outValue;
+        }
+    } else {
+        if (PyErr_Occurred())
+            PyErr_Print();
+        fprintf(stderr, "Cannot find function \"%s\"\n", method);
+    }
+    Py_XDECREF(pFunc);
+    Py_DECREF(pModule);
+    return outValue;
+}
+
+void *swiftvim_command(const char *command) {
+    return swiftvim_call("vim", "command", command);
+}
+
+void *swiftvim_expr(const char *command) {
+    return swiftvim_call("vim", "expr", command);
+}
+
+void *swiftvim_decref(void *value) {
+    Py_DECREF(value);
+    return value;
+}
+
+void *swiftvim_incref(void *value) {
+    Py_INCREF(value);
+    return value;
+}
+
+const char *swiftvim_asstring(void *value) {
+    if (value == NULL) {
+        return "";
+    }
+    return PyString_AsString(value);
+}
+
+int swiftvim_asint(void *value) {
+    return PyInt_AsLong(value);
+}
+
+void swiftvim_initialize() {
+    Py_Initialize();
+    // For unit tests, we fake out the vim module
+    // to make the tests as pure as possible.
+#ifdef SPMVIM_LOADSTUB_RUNTIME
+    // Assume that tests are running from the source root
+    // We could do something better.
+    char cwd[1024];
+    if (getcwd(cwd, sizeof(cwd)) == NULL)
+        fprintf(stderr, "GarbPWD");
+    strcat(cwd, "/Tests/VimInterfaceTests/MockVimRuntime/");
+    fprintf(stderr, "Adding test import path: %s \n", cwd);
+    PyObject* sysPath = PySys_GetObject((char*)"path");
+    PyObject* programName = PyString_FromString(cwd);
+    PyList_Append(sysPath, programName);
+    Py_DECREF(programName);
+#endif
+}
+
+void swiftvim_finalize() {
+    Py_Finalize();
+}
+

--- a/Sources/swiftvim.c
+++ b/Sources/swiftvim.c
@@ -1,0 +1,39 @@
+// Core Python -> Swift bootstrap
+// The vim plugin is expected to call swiftvim_load when
+// it's time to initialize the plugin
+#include <Python.h>
+#include <unistd.h>
+
+// Plugin init is called to bootstrap the plugin in vim
+// It should deffinitely return
+extern void plugin_init();
+
+static PyObject *swiftvimError;
+
+// Python method `load`
+static PyObject * swiftvim_load(PyObject *self, PyObject *args);
+
+static PyMethodDef swiftvimMethods[] = {
+    {"load",  swiftvim_load, METH_VARARGS,
+     "Load the plugin."},
+    {NULL, NULL, 0, NULL}        /* Sentinel */
+};
+
+PyMODINIT_FUNC initswiftvim(void) {
+    PyObject *m;
+
+    m = Py_InitModule("swiftvim", swiftvimMethods);
+    if (m == NULL)
+        return;
+
+    swiftvimError = PyErr_NewException("swiftvim.error", NULL, NULL);
+    Py_INCREF(swiftvimError);
+    PyModule_AddObject(m, "error", swiftvimError);
+}
+
+static PyObject *swiftvim_load(PyObject *self, PyObject *args)
+{
+    plugin_init();
+    return Py_BuildValue("i", 0);
+}
+

--- a/Tests/SPMVimTests/SPMVimTests.swift
+++ b/Tests/SPMVimTests/SPMVimTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import SPMVim
+@testable import EditorService
 
 class SPMVimTests: XCTestCase {
     static var allTests = [

--- a/Tests/VimInterfaceTests/CallingTests.swift
+++ b/Tests/VimInterfaceTests/CallingTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import VimInterface
+
+/// These tests make assertions about "vim.py"
+class VimInterfaceTests: XCTestCase {
+    static var allTests = [
+        ("testExprString", testExprString),
+        ("testExprInt", testExprInt),
+        ("testCommandNone", testCommandNone),
+    ]
+
+    func testExprString() {
+        swiftvim_initialize()
+        "VALUE".withCString { cStr in
+            let result = swiftvim_expr(
+              UnsafeMutablePointer(mutating: cStr))
+            let str = swiftvim_asstring(result)
+
+            let value = String(cString: str!)
+            XCTAssertEqual(value, "VALUE")
+        }
+        swiftvim_finalize()
+    }
+
+    func testCommandNone() {
+        swiftvim_initialize()
+        "VALUE".withCString { cStr in
+            // This command returns a None
+            let result = swiftvim_command(
+              UnsafeMutablePointer(mutating: cStr))
+            // This should return a null
+            let str = swiftvim_asstring(result)
+            XCTAssertNil(str)
+        }
+        swiftvim_finalize()
+    }
+
+    // Low level testing
+    func testExprInt() {
+        swiftvim_initialize()
+        // expr_int is a function that returns an int
+        "vim".withCString { moduleCStr in
+            "expr_int".withCString { fCStr in
+                "1".withCString { argCStr in
+                    let result = swiftvim_call(
+                        UnsafeMutablePointer(mutating: moduleCStr),
+                        UnsafeMutablePointer(mutating: fCStr),
+                        UnsafeMutablePointer(mutating: argCStr))
+                    let value = swiftvim_asint(result)
+                    XCTAssertEqual(value, 1)
+                }
+            }
+        }
+        swiftvim_finalize()
+    }
+}

--- a/Tests/VimInterfaceTests/MockVimRuntime/vim.py
+++ b/Tests/VimInterfaceTests/MockVimRuntime/vim.py
@@ -1,0 +1,12 @@
+def command(value):
+    return None
+
+def expr(value):
+    return value
+
+def expr_int(value):
+    return int(value)
+
+def expr_bool(value):
+    return True
+

--- a/Utils/main.py
+++ b/Utils/main.py
@@ -1,0 +1,12 @@
+import os
+import sys
+# Add the location of of the .so to the python path
+build_root = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+        '.build')
+sys.path.append(build_root)
+
+import swiftvim
+print("build_root", build_root)
+stats = swiftvim.load()
+result = swiftvim.load()
+print("Loaded spmvim", result)


### PR DESCRIPTION
This patch adds the ability to call vimscript from swift, and within the
Vim's main run loop.

Additonally, we an run vimscript from swift bycCall `command` and `exec`
through a high level interface "VimInterface"

VimCore: Vim -> Swift
- Vim calls our python helper program
- Calling a c function from python
- Calling `plugin_init` from the c function
VimCore is where `plugin_init` lives for SPMVim
This is the core bootstrap of the plugin

VimInterface: Swift -> Vim
- Call vim `eval` and command
- Swift functions interface with `swiftvim_*` API
- Internally, it uses Pythons C API

Currently, compile dylib with Makefile. It seems like SPM can handle
this task with some more effort, but that is left for a later exercise.

The fact that this uses Python as a glue layer is irrelevant. That
implementation detail should be hidden from Swift.

This is Step1 towards writing the entire plugin and a good RPC layer in
Swift.