### PR TITLE
Python 3 support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "SwiftServerHttp",
+        "repositoryURL": "https://github.com/swift-vim/http",
+        "state": {
+          "branch": null,
+          "revision": "671be3123752a8eebd18dccb9321e1dfcae8f9c0",
+          "version": null
+        }
+      },
+      {
         "package": "Nimble",
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
@@ -52,15 +61,6 @@
         "state": {
           "branch": "master",
           "revision": "810f040e97ebe97210d64a644d8d386e35a6358d",
-          "version": null
-        }
-      },
-      {
-        "package": "SwiftServerHttp",
-        "repositoryURL": "https://github.com/swift-vim/http",
-        "state": {
-          "branch": null,
-          "revision": "671be3123752a8eebd18dccb9321e1dfcae8f9c0",
           "version": null
         }
       }

--- a/Sources/swiftvim.c
+++ b/Sources/swiftvim.c
@@ -19,6 +19,34 @@ static PyMethodDef swiftvimMethods[] = {
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 
+
+
+#if PY_MAJOR_VERSION == 3
+
+static struct PyModuleDef swiftvimmodule = {
+    PyModuleDef_HEAD_INIT,
+    "swiftvim", /* name of module */
+    NULL, /* module documentation, may be NULL */
+    -1, /* size of per-interpreter state of the module,
+        or -1 if the module keeps state in global variables. */
+    swiftvimMethods
+};
+
+PyMODINIT_FUNC PyInit_swiftvim(void) {
+    PyObject *m;
+
+    m = PyModule_Create(&swiftvimmodule);
+    if (m == NULL)
+        return NULL;
+
+    swiftvimError = PyErr_NewException("swiftvim.error", NULL, NULL);
+    Py_INCREF(swiftvimError);
+    PyModule_AddObject(m, "error", swiftvimError);
+    return m;
+}
+
+#else 
+
 PyMODINIT_FUNC initswiftvim(void) {
     PyObject *m;
 
@@ -30,6 +58,8 @@ PyMODINIT_FUNC initswiftvim(void) {
     Py_INCREF(swiftvimError);
     PyModule_AddObject(m, "error", swiftvimError);
 }
+#endif
+
 
 static int calledPluginInit = 0;
 

--- a/Utils/make_lib.sh
+++ b/Utils/make_lib.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Find vims and pythons
+# Tested under:
+# - brew vim8 / python 2.7
+# - brew vim8 / python 3.6.5
+# - brew macvim / python 3.6.5
+# - custom built vims against OSX python
+
+function realpath() {
+    echo $(python -c "import os; print os.path.realpath('$1')")
+}
+
+VIM_PATH=""
+WHICH_VIM=$(realpath $(which vim))
+
+if [[ $(echo $(file $WHICH_VIM) | grep -q shell; echo $?) -eq 0 ]]; then
+    # Assumptions about vim inside of MacVim.app which is a script
+    if [[ $(cat $WHICH_VIM | grep -q MacVim; echo $?) -eq 0 ]]; then
+        VIM_PATH=$(dirname $(dirname $WHICH_VIM))/MacOS/Vim
+    fi
+else
+    VIM_PATH=$WHICH_VIM
+fi
+
+if [[ $(test -x "$VIM_PATH") -ne 0 ]]; then
+    >&2 echo "error: can't find vim"
+    exit 1
+fi
+
+_PYTHON_LINKED=$(otool -l $VIM_PATH  | grep Python | awk '{ print $2 }')
+PYTHON_F=$(realpath $_PYTHON_LINKED)
+
+# Test if we've got a dylib on our hands.
+if [[ $(echo $(file "$PYTHON_F") | grep -q dynamic; echo $?) -ne 0 ]]; then
+    # Fall back to the default python
+    DEFAULT_PY=$(realpath "/System/Library/Frameworks/Python.framework/Python")
+    >&2 echo "warning: can't find linked python. Falling back to $DEFAULT_PY."
+    >&2 echo "this may not work out so well for many reasons"
+    PYTHON_F=$DEFAULT_PY
+fi
+
+function python_info() {
+    echo "Found vim executable $VIM_PATH"
+    echo "Found python executable $PYTHON_F"
+}
+
+function linked_python() {
+    echo $PYTHON_F
+}
+
+function python_inc_dir() {
+    ROOT=$(dirname $PYTHON_F)
+    if [[ -d $ROOT/Headers ]]; then
+        echo $ROOT/Headers
+        return
+    fi
+
+    # Handle builds of python like Apple system pythons
+    # i.e.
+    # /System/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7
+    VERSION_INC=$(ls $ROOT/include | head -1)
+    if [[ -d $ROOT/include/$VERSION_INC ]]; then
+        echo $ROOT/include/$VERSION_INC
+        return
+    fi
+}
+


### PR DESCRIPTION
- Dynamically find python variables for OSX based on vim linker info. This is
somewhat fickle, but should work for the OSX case.
- Create make lib of helper shell functions
- Add conditional code for python 3
- Test on several vim variants