### PR TITLE
Decouple EditorService from Vim / Remove Python

### DIFF
--- a/Examples/failing_build.log
+++ b/Examples/failing_build.log
@@ -7,11 +7,10 @@ Compile Swift Module 'LogParser' (1 sources)
 Compile Swift Module 'SwiftCompilationDatabase' (1 sources)
 Compile Swift Module 'EditorService' (1 sources)
 Compile Swift Module 'VimCore' (4 sources)
-/Users/jerrymarino/Projects/SwiftPackageManager.vim/Sources/VimCore/PluginMain.swift:10:1: error: expressions are not allowed at the top level
+/Users/jerrymarino/Projects/SwiftPackageManager.vim/Sources/VimCore/VimValue.swift:3:1: error: expressions are not allowed at the top level
 a
 ^
-/Users/jerrymarino/Projects/SwiftPackageManager.vim/Sources/VimCore/PluginMain.swift:10:1: error: use of unresolved identifier 'a'
+/Users/jerrymarino/Projects/SwiftPackageManager.vim/Sources/VimCore/VimValue.swift:3:1: error: use of unresolved identifier 'a'
 a
 ^
-error: terminated(1): /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-build-tool -f /Users/jerrymarino/Projects/SwiftPackageManager.vim/.build/debug.yaml VimCore.dylib
-mv: .build/debug/SPMVim: No such file or directory
+

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ build-impl: py_vars
 build-impl:
 	@echo "Building.."
 	@mkdir -p .build/$(CONFIG)
-	@swift build -c $(CONFIG) $(SWIFT_OPTS) | tee $(LAST_LOG)
+	@swift build -c $(CONFIG) $(SWIFT_OPTS)  -Xswiftc "-target"  -Xswiftc "x86_64-apple-macosx10.12" | tee $(LAST_LOG)
 
 # Build and install the command line program
 .PHONY: install_cli
@@ -123,3 +123,19 @@ reset:
 .PHONY: push_error
 push_error:
 	cat Examples/failing_build.log > .build/last_build.log
+
+.PHONY: clear_error
+clear_error:
+	echo "" > .build/last_build.log
+
+.PHONY: pe
+pe: push_error
+
+.PHONY: ce
+ce: clear_error
+
+stress:
+	for i in $$(seq 1 15); do make pe && make ce && sleep 1; done
+
+killvim:
+	for p in $$(ps aux | grep vim | awk ' { print $$2 }' ); do kill -9 $$p; done

--- a/Package.swift
+++ b/Package.swift
@@ -37,13 +37,16 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(name: "EditorService",
-            dependencies: ["LogParser", "SKQueue"]),
+            dependencies: ["LogParser", "SKQueue", "SPMProtocol"]),
         .target(
             name: "SPMVim",
             dependencies: ["Commandant", "LogParser", "EditorService"]),
         .target(
             name: "SPMVimPlugin",
-            dependencies: ["VimCore", "HTTP", "EditorService"]),
+            dependencies: ["VimCore", "HTTP", "EditorService", "SPMProtocol"]),
+
+        // Client <-> Server messages
+        .target(name: "SPMProtocol"),
         .testTarget(
             name: "SPMVimTests",
             dependencies: ["EditorService", "VimCore"]),

--- a/Sources/SPMProtocol/DiagnosticMessage.swift
+++ b/Sources/SPMProtocol/DiagnosticMessage.swift
@@ -1,0 +1,61 @@
+
+public struct Diagnostic: Codable {
+    public struct Location: Codable {
+        public let lineNum: Int
+        public let columnNum: Int
+        public let filepath: String
+
+        public init(lineNum: Int, columnNum: Int, filepath: String) {
+            self.lineNum = lineNum
+            self.columnNum = columnNum
+            self.filepath = filepath
+        }
+    }
+
+    public struct LocationPoint: Codable {
+        public let lineNum: Int
+        public let columnNum: Int
+        public init(lineNum: Int, columnNum: Int) {
+            self.lineNum = lineNum
+            self.columnNum = columnNum
+        }
+    }
+
+    public struct LocationExtent: Codable  {
+        public let start: LocationPoint
+        public let end: LocationPoint?
+
+        public init(start: LocationPoint, end: LocationPoint?) {
+            self.start = start
+            self.end = end
+        }
+    }
+
+    public let text: String
+    public let fixitAvailable: Bool
+    public let isError: Bool
+
+    public let location: Location
+    public let locationExtent: LocationExtent?
+
+    public init(text: String, fixitAvailable: Bool, isError: Bool, location:
+        Location, locationExtent: LocationExtent) {
+        self.text = text
+        self.isError = isError
+        self.fixitAvailable = fixitAvailable
+        self.location = location
+        self.locationExtent = locationExtent
+    }
+}
+
+// Message that diagnostics are available.
+public struct DiagnosticMessage: Codable {
+    public let originFile: String?
+    public let diagnostics: [Diagnostic]
+    public init(originFile: String?,
+                diagnostics: [Diagnostic]) {
+        self.originFile = originFile
+        self.diagnostics = diagnostics
+    }
+}
+

--- a/Sources/SPMVim/main.swift
+++ b/Sources/SPMVim/main.swift
@@ -126,7 +126,8 @@ struct EditorServiceCommand: CommandProtocol {
 
     func run(_ options: Options) -> Result<(), BasicError> {
         let host = "http://localhost:" + options.port
-        let service = EditorService(host: host, authToken: options.authToken)
+        let service = EditorService(host: host, authToken: options.authToken, 
+            path: options.path)
         service.start()
         return .success(())
     }
@@ -135,17 +136,20 @@ struct EditorServiceCommand: CommandProtocol {
 struct EditorServiceOptions: OptionsProtocol {
     let authToken: String
     let port: String
+    let path: String
 
-    static func create(_ authToken: String) -> (String) -> EditorServiceOptions {
-        return { port in
-          EditorServiceOptions(authToken: authToken, port: port)
-        }
+    static func create(_ authToken: String) -> (String) -> (String) -> EditorServiceOptions {
+        return { port in { path in
+            EditorServiceOptions(authToken: authToken, port: port,
+                path: path)
+        } }
     }
 
     static func evaluate(_ m: CommandMode) -> Result<EditorServiceOptions, CommandantError<BasicError>> {
         return create
             <*> m <| Argument(defaultValue: "", usage: "The auth token for the editor interface")
             <*> m <| Option(key: "port", defaultValue: "0", usage: "port of the editor interface")
+            <*> m <| Option(key: "path", defaultValue: "", usage: "path of file in the package")
     }
 }
 

--- a/Sources/SPMVimPlugin/VimCoreBootstrap.swift
+++ b/Sources/SPMVimPlugin/VimCoreBootstrap.swift
@@ -21,7 +21,12 @@ public func SetSharedPlugin(_ plugin: VimPlugin) {
 
 @_cdecl("plugin_user_event")
 public func plugin_user_event(event: Int, context: UnsafePointer<Int8>) -> UnsafePointer<Int8>? {
-    let ret = SharedPlugin?.pluginEvent(event: event,
+    // FIXME: Move this somewhere else.
+    // Ideally, this can be installed into Vim dynamically
+    if event == 2 {
+        VimRunLoop.main.runOnce()
+    }
+    SharedPlugin?.pluginEvent(event: event,
         context: String(cString: context))
-    return UnsafePointer<Int8>(ret)
+    return nil
 }

--- a/Sources/VimCore/VimSupport.swift
+++ b/Sources/VimCore/VimSupport.swift
@@ -110,11 +110,10 @@ extension VimSupport {
         if bufferNum < 0 {
             return
         }
-        Vim.command("sign undefine icm_dummy_sign")
+        Vim.command("try | exec 'sign undefine icm_dummy_sign' | catch /E155/ | endtry")
         Vim.command("sign unplace \(signId) buffer=\(bufferNum)")
     }
 }
-
 
 extension VimSupport {
     /// Highlight a range in the current window starting from
@@ -133,13 +132,12 @@ extension VimSupport {
         let (lineNum, columnNum) = lineAndColumnNumbersClamped(lineNum: lineNum, columnNum: columnNum)
         if lineEndNum == nil || columnEndNum == nil {
             return getIntValue(
-                "matchadd('\(group)', '%\(lineNum)%{\(columnNum)c')")
+                "matchadd('\(group)', '\\%\(lineNum)l\\%\(columnNum)c')")
         }
         // -1 and then +1 to account for column end not included in the range.
         var (lineEndNum, columnEndNum) = lineAndColumnNumbersClamped(
             lineNum: lineEndNum, columnNum: (columnEndNum ?? 0) - 1)
         columnEndNum += 1
-
         return getIntValue(
             "matchadd('\(group)', '%\(lineNum)l%\(columnNum)c_.\\{{-}}%\(lineEndNum)l%\(columnEndNum)c')")
     }
@@ -212,8 +210,9 @@ extension VimSupport {
         // FIXME: Check types
         for matchValue in matches {
             if let match = matchValue.asDictionary(),
-                match["group"]?.asString()?.hasPrefix("Icm") == true {
-                Vim.eval("matchdelete(\(match["id"]!))")
+                match["group"]?.asString()?.hasPrefix("Icm") == true,
+                let id = match["id"]?.asInt() {
+                Vim.eval("matchdelete(\(id))")
             }
         }
     }

--- a/Sources/VimCore/VimTask.swift
+++ b/Sources/VimCore/VimTask.swift
@@ -1,31 +1,83 @@
 import Foundation
 
+private var rlLock = os_unfair_lock_s()
+
+/// Hook into Vim's main thread in a thread safe way.
+/// Vim is a single threaded, thread unsafe program so any code that touches
+/// vim must run on the main thread.
+/// This includes any function calls and associated data.
+/// Beware, that not adhereing to this will case several issues and thread
+/// safety is not validated.
+public final class VimRunLoop {
+    private let source: CFRunLoopSource 
+    private let runLoopRef: CFRunLoop
+    public let runLoop: RunLoop
+
+    private init() { 
+        let runLoop = RunLoop.current
+        let runLoopRef =  RunLoop.current.getCFRunLoop()
+        var ctx = CFRunLoopSourceContext()
+        let source = CFRunLoopSourceCreate(nil, 0, UnsafeMutablePointer(&ctx))!
+        CFRunLoopAddSource(runLoopRef, source, CFRunLoopMode.commonModes)
+        self.runLoopRef = runLoopRef
+        self.runLoop = runLoop
+        self.source = source
+        CFRunLoopSourceSignal(source);
+        CFRunLoopWakeUp(runLoopRef);
+    }
+
+    public func runOnce() {
+        os_unfair_lock_lock(&rlLock)
+        CFRunLoopSourceSignal(source);
+        CFRunLoopWakeUp(runLoopRef);
+        CFRunLoopRunInMode(CFRunLoopMode.defaultMode, 0, true)
+        os_unfair_lock_unlock(&rlLock)
+    }
+
+    /// Schedule the block to run
+    public func perform(_ bl: @escaping (() -> Void)) {
+        os_unfair_lock_lock(&rlLock)
+        runLoop.perform(bl)
+        CFRunLoopRunInMode(CFRunLoopMode.defaultMode, 0, true)
+        os_unfair_lock_unlock(&rlLock)
+    }
+
+    public static var main: VimRunLoop = {
+        var rl: VimRunLoop!
+        os_unfair_lock_lock(&rlLock)
+        rl = VimRunLoop()
+        os_unfair_lock_unlock(&rlLock)
+        return rl
+    }()
+}
+
 /// Create tasks for new threads or use existing ones
 /// The program should be as synchronous as possible
 public final class VimTask<T> : NSObject {
     public typealias VimTaskBlock = () -> T
 
-    public init (on thread: Thread? = nil, bl: @escaping VimTaskBlock) {
+    public init(main: Bool? = false, bl: @escaping VimTaskBlock) {
         self.bl = bl
-        self.thread = thread
+        self.main = main ?? false
         super.init()
     }
 
-    /// Execute a block on Vim's main thread
-    public static func onMain(_ bl: @escaping VimTaskBlock) -> T {
-        let semaphore = DispatchSemaphore(value: 0)
-        var data: T!
-        let t = VimTask(on: Thread.main) {
-            data = bl()
-            semaphore.signal()
-            return data
+    /// Schedule on the main
+    public static func onMain(_ bl: @escaping VimTaskBlock) {
+        if Thread.current == Thread.main {
+            _ = bl()
+            return
         }
-        t.run()
-        semaphore.wait()
-        return data
+        VimTask(main: true, bl: bl).run()
     }
 
-    var isDone: Bool {
+    public static func ensureMain() {
+        guard Thread.current == Thread.main else {
+            fatalError("error: main thread check failed")
+        }
+    }
+
+    public var isDone: Bool {
         var x = false
         mutQueue.sync {
             x = self.done
@@ -34,21 +86,24 @@ public final class VimTask<T> : NSObject {
     }
 
     public func run() {
-        if let thread = self.thread {
-            self.perform(#selector(start), with: thread)
+        if main {
+            VimRunLoop.main.perform {
+                () -> Void in
+                self.start(sender: nil)
+            }
         } else {
-            Thread.detachNewThreadSelector(#selector(start), toTarget:self, with: nil) 
+            Thread.detachNewThreadSelector(#selector(start), toTarget:self, with: nil)
         }
     }
 
     private let bl: VimTaskBlock
-    private let thread: Thread?
+    private let main: Bool
     private let mutQueue = DispatchQueue(label: "com.bs.threadMut")
     private var done = false
     private var running = false
 
     @objc
-    private func start(sender: Any!) {
+    private func start(sender: Any?) {
         mutQueue.sync {
             self.running = true
         }

--- a/Sources/VimCore/VimValue.swift
+++ b/Sources/VimCore/VimValue.swift
@@ -23,7 +23,7 @@ public class VimValue {
 
     // Mark - Casting
 
-    func asString() -> String? {
+    public func asString() -> String? {
         guard let value = self.value else { return nil }
         guard let cStr = swiftvim_asstring(value) else {
             return nil
@@ -31,7 +31,7 @@ public class VimValue {
         return String(cString: cStr)
     }
 
-    func asInt() -> Int? {
+    public func asInt() -> Int? {
         // Generally, eval results are returned as strings
         // Perhaps there is a better way to express this.
         if let strValue = asString(), 
@@ -42,19 +42,19 @@ public class VimValue {
         return Int(swiftvim_asint(value))
     }
 
-    func asList() -> VimList? {
+    public func asList() -> VimList? {
         guard let value = self.value else { return nil }
         return VimList(value: value)
     }
 
-    func asDictionary() -> VimDictionary? {
+    public func asDictionary() -> VimDictionary? {
         guard let value = self.value else { return nil }
         return VimDictionary(value: value)
     }
 }
 
 // A Dictionary
-public struct VimDictionary {
+public class VimDictionary {
     private let value: UnsafeVimValue
 
     fileprivate init(value: UnsafeVimValue) {
@@ -67,7 +67,7 @@ public struct VimDictionary {
 
     public var keys: VimList {
         guard let list = VimValue(value: swiftvim_dict_keys(value),
-                  doDeInit: true).asList() else {
+                  doDeInit: false).asList() else {
             fatalError("Can't get keys")
          }
          return list
@@ -75,7 +75,7 @@ public struct VimDictionary {
 
     public var values: VimList {
         guard let list =  VimValue(value: swiftvim_dict_values(value),
-                  doDeInit: true).asList() else {
+                  doDeInit: false).asList() else {
             fatalError("Can't get values")
         }
         return list


### PR DESCRIPTION
- Factor out handler
- Add better diagnostics, add try
- Improve error messaging
- Factor out protocol. The core editor service is decoupled from Vim.
- Fix unremoval bug
- Add VimRunLoop, a way to hook into Vims run loop